### PR TITLE
RabbitMQ with "/" as vhost

### DIFF
--- a/src/main/java/de/codewhite/jmet/target/impl/RabbitMQTarget.java
+++ b/src/main/java/de/codewhite/jmet/target/impl/RabbitMQTarget.java
@@ -25,11 +25,12 @@ public class RabbitMQTarget extends JMSTarget {
         RMQConnectionFactory implFactory = new RMQConnectionFactory();
 
         try {
-			String uri = "amqp://" + getUser() + ":" + getPassword() + "@" + getHost() + ":" + getPort();
+            String uri = "amqp://" + getUser() + ":" + getPassword() + "@" + getHost() + ":" + getPort();
 
-			if (!getVhost().equals("/")) {
-				uri = uri + "/" + getVhost();
-			}
+            if (!getVhost().equals("/")) {
+                uri = uri + "/" + getVhost();
+            }
+            implFactory.setUri(uri);
             factory = implFactory;
             connection = factory.createConnection(getUser(), getPassword());
             session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);

--- a/src/main/java/de/codewhite/jmet/target/impl/RabbitMQTarget.java
+++ b/src/main/java/de/codewhite/jmet/target/impl/RabbitMQTarget.java
@@ -25,7 +25,11 @@ public class RabbitMQTarget extends JMSTarget {
         RMQConnectionFactory implFactory = new RMQConnectionFactory();
 
         try {
-            implFactory.setUri("amqp://" + getUser() + ":" + getPassword() + "@" + getHost() + ":" + getPort() + "/" + getVhost());
+			String uri = "amqp://" + getUser() + ":" + getPassword() + "@" + getHost() + ":" + getPort();
+
+			if (!getVhost().equals("/")) {
+				uri = uri + "/" + getVhost();
+			}
             factory = implFactory;
             connection = factory.createConnection(getUser(), getPassword());
             session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);


### PR DESCRIPTION
Jmet doesn't work correctly when "/" as vhost. In this case a connection uri has double "//" at the end. It causes connection error.
