### PR TITLE
Use HTTPS to Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
             <id>central</id>
             <name>Maven Repository Switchboard</name>
             <layout>default</layout>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
               <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Maven returns HTTP 501 at least for RabbitMQ, when not accessed via HTTPS